### PR TITLE
Add commenting and status updating capabilities to test-built-container

### DIFF
--- a/test-built-container
+++ b/test-built-container
@@ -21,6 +21,9 @@ GITHUB_STATUS_TOKEN=$GITHUB_AUTH_TOKEN
 COMMIT=$COMMIT_SHA1
 PR_ID=$PULL_REQUEST_ID
 SOFTWARE=$CONTAINER
+HDR1="Accept: application/vnd.github.v3+json"
+HDR2="Authorization: token $GITHUB_STATUS_TOKEN"
+
 
 ###################
 # Print help {{{1 #
@@ -135,18 +138,16 @@ function test_container {
 
 function send_comment {
 	local comment=$1
-	local hdr1="Accept: application/vnd.github.v3+json"
-	local hdr2="Authorization: token $GITHUB_STATUS_TOKEN"
 	local githuburl="https://api.github.com/repos/$REPO/commits/$COMMIT/comments"
+	local header1=$HDR1
 	if [ -n "$PR_ID" ] ; then
-		hdr1="Accept:application/vnd.github.v3.raw+json"
+		header1="Accept:application/vnd.github.v3.raw+json"
 		githuburl="https://api.github.com/repos/$REPO/issues/$PR_ID/comments"
 	fi
 	#echo "Cmd sent:"
-	#echo "curl -H '$hdr1' -H '$hdr2' -d '{\"body\": \"$comment\"}' $githuburl"
-	#echo
-	curl -H "$hdr1" \
-		-H "$hdr2" \
+	#echo "curl -H '$header1' -H '$HDR2' -d '{\"body\": \"$comment\"}' $githuburl"
+        curl -H "$header1" \
+                -H "$HDR2" \
 		-d "{\"body\": \"$comment\"}" \
 		"$githuburl"
 }
@@ -159,17 +160,13 @@ function send_status {
 	local software=$1
 	local status=$2
 	local msg=$3
-	local hdr1="Accept: application/vnd.github.v3+json"
-	local hdr2="Authorization: token $GITHUB_STATUS_TOKEN"
+        local json="{\"description\": \"$msg\",\"state\": \"$status\",\"context\": \"biocontainers/status/check/$SOFTWARE\"}"
 	local githuburl="https://api.github.com/repos/$REPO/statuses/$COMMIT"
 	case "$status" in
 		"s" | "success")
-			#echo "All tests were successful for $CONTAINER_IMAGE"  
 			status="success"
 			;;
 		"f" | "failure")
-			#echo "$CONTAINER_IMAGE testing failed on command:"
-			#echo "$msg"
 			status="failure"
 			;;
 		"n" | "none")
@@ -177,12 +174,11 @@ function send_status {
 		*)
 			msg ERROR "Unknown test status: $status"
 			return 1;;
-	esac 
-	local json="{\"description\": \"$msg\",\"state\": \"$status\",\"context\": \"biocontainers/status/check/$SOFTWARE\"}"
+	esac
 	#echo "Curl command:"
-	#echo "curl -H '$hdr1' -H '$hdr2' -d '$json' $githuburl"
-	curl -H "$hdr1" \
-		-H "$hdr2" \
+	#echo "curl -H '$HDR1' -H '$HDR2' -d '$json' $githuburl"
+        curl -H "$HDR1" \
+                -H "$HDR2" \
 		-d "$json" \
 		"$githuburl"
 }
@@ -216,6 +212,6 @@ if [ -f "$CMDS_FILE" ] ; then
 	done <"$CMDS_FILE"
 	send_status $CONTAINER_IMAGE "success" "All tests successful"
 else
-	echo "No $CMDS_FILE (test file) present, skipping tests"
+	#echo "No $CMDS_FILE (test file) present, skipping tests"
 	send_comment "No $CMDS_FILE (test file) present, skipping tests"
 fi

--- a/test-built-container
+++ b/test-built-container
@@ -143,11 +143,11 @@ function send_comment {
 		githuburl="https://api.github.com/repos/$REPO/issues/$PR_ID/comments"
 	fi
 	#echo "Cmd sent:"
-	echo "curl -H '$header1' -H '$HDR2' -d '{\"body\": \"$comment\"}' $githuburl"
-        #curl -H "$header1" \
-                #-H "$HDR2" \
-		#-d "{\"body\": \"$comment\"}" \
-		#"$githuburl"
+	#echo "curl -H '$header1' -H '$HDR2' -d '{\"body\": \"$comment\"}' $githuburl"
+        curl -H "$header1" \
+                -H "$HDR2" \
+		-d "{\"body\": \"$comment\"}" \
+		"$githuburl"
 }
 
 ###############
@@ -175,10 +175,10 @@ function send_status {
 	esac
 	#echo "Curl command:"
 	echo "curl -H '$HDR1' -H '$HDR2' -d '$json' $githuburl"
-        #curl -H "$HDR1" \
-                #-H "$HDR2" \
-		#-d "$json" \
-		#"$githuburl"
+        curl -H "$HDR1" \
+                -H "$HDR2" \
+		-d "$json" \
+		"$githuburl"
 }
 
 #############

--- a/test-built-container
+++ b/test-built-container
@@ -14,7 +14,12 @@ YES=yes
 
 DEBUG=0
 CONTAINER_IMAGE=
-CMDS_FILE=test_cmds.txt
+#CMDS_FILE=test_cmds.txt
+CMDS_FILE=
+REPO="BioContainers/containers"
+GITHUB_STATUS_TOKEN=$GITHUB_AUTH_TOKEN
+COMMIT=$COMMIT_SHA1
+PR_ID=$PULL_REQUEST_ID
 
 ###################
 # Print help {{{1 #
@@ -23,6 +28,7 @@ CMDS_FILE=test_cmds.txt
 function print_help {
 	echo "Usage: $PROG_NAME [options] container_image"
 	echo
+	echo "   -t, --test-cmds            Path to test-cmds file."
 	echo "   -g, --debug                Debug mode."
 	echo "   -h, --help                 Print this help message."
 }
@@ -81,6 +87,7 @@ function read_args {
 		case $1 in
 			-g|--debug)             DEBUG=$((DEBUG + 1)) ;;
 			-h|--help)              print_help ; exit 0 ;;
+			-t|--test-cmds)		shift; CMDS_FILE=$1 ;; 
 			-|--|--*)               msg ERROR "Illegal option $1." ;;
 			-?)                     msg ERROR "Unknown option $1." ;;
 			-[^-]*) split_opt=$(echo $1 | sed 's/^-//' | sed 's/\([a-zA-Z]\)/ -\1/g') ; set -- $1$split_opt "${@:2}" ;;
@@ -110,7 +117,51 @@ function test_container {
 
 	[ -z "$entrypoint" ] || entrypoint_arg="--entrypoint=$1"
 
-	docker run $entrypoint_arg $CONTAINER_IMAGE $args || exit 1
+	echo "Running the following command:"
+	echo "docker run $entrypoint_arg $CONTAINER_IMAGE $args"
+	#docker run $entrypoint_arg $CONTAINER_IMAGE $args || exit 1
+	{
+		docker run $entrypoint_arg $CONTAINER_IMAGE $args &&
+		return 0
+	} || {
+		return 1
+	}
+}
+
+################
+# Send comment #
+################
+
+function send_comment {
+	local comment=$1
+	local hdr1="Accept: application/vnd.github.v3+json"
+	local hdr2="Authorization: token $GITHUB_STATUS_TOKEN"
+	local githuburl="https://api.github.com/repos/$REPO/commits/$COMMIT/comments"
+	if [ -n "$PR_ID" ] ; then
+		hdr1="Accept:application/vnd.github.v3.raw+json"
+		githuburl="https://api.github.com/repos/$REPO/issues/$PR_ID/comments"
+	fi
+	#echo "Cmd sent:"
+	#echo "curl -H '$hdr1' -H '$hdr2' -d '{\"body\": \"$comment\"}' $githuburl"
+	#echo
+	curl -H "$hdr1" \
+		-H "$hdr2" \
+		-d "{\"body\": \"$comment\"}" \
+		"$githuburl"
+}
+
+###############
+# Send status #
+###############
+
+function send_status {
+	local software=$1
+	local status=$2
+	local msg=$3
+	local stat_disp="success"
+	local hdr1="Accept: application/vnd.github.v3+json"
+	local hdr2="Authorization: token $GITHUB_STATUS_TOKEN"
+	#case success in 
 }
 
 #############
@@ -134,8 +185,10 @@ if [ -f "$CMDS_FILE" ] ; then
 			entrypoint=
 			args=$line
 		fi
-		test_container "$entrypoint" "$args"
+		#test_container "$entrypoint" "$args"
+		test_container "$entrypoint" "$args" || echo "Test FAILED"
 	done <"$CMDS_FILE"
 else
-	echo "No $CMDS_FILE present, skipping tests"
+	echo "No $CMDS_FILE (test file) present, skipping tests"
+	send_comment "No $CMDS_FILE (test file) present, skipping tests"
 fi

--- a/test-built-container
+++ b/test-built-container
@@ -179,8 +179,12 @@ function send_status {
 			return 1;;
 	esac 
 	local json="{\"description\": \"$msg\",\"state\": \"$status\",\"context\": \"biocontainers/status/check/$SOFTWARE\"}"
-	echo "Curl command:"
-	echo "curl -H '$hdr1' -H '$hdr2' -d '$json' $githuburl"
+	#echo "Curl command:"
+	#echo "curl -H '$hdr1' -H '$hdr2' -d '$json' $githuburl"
+	curl -H "$hdr1" \
+		-H "$hdr2" \
+		-d "$json" \
+		"$githuburl"
 }
 
 #############

--- a/test-built-container
+++ b/test-built-container
@@ -20,6 +20,7 @@ REPO="BioContainers/containers"
 GITHUB_STATUS_TOKEN=$GITHUB_AUTH_TOKEN
 COMMIT=$COMMIT_SHA1
 PR_ID=$PULL_REQUEST_ID
+SOFTWARE=$CONTAINER
 
 ###################
 # Print help {{{1 #
@@ -158,10 +159,28 @@ function send_status {
 	local software=$1
 	local status=$2
 	local msg=$3
-	local stat_disp="success"
 	local hdr1="Accept: application/vnd.github.v3+json"
 	local hdr2="Authorization: token $GITHUB_STATUS_TOKEN"
-	#case success in 
+	local githuburl="https://api.github.com/repos/$REPO/statuses/$COMMIT"
+	case "$status" in
+		"s" | "success")
+			#echo "All tests were successful for $CONTAINER_IMAGE"  
+			status="success"
+			;;
+		"f" | "failure")
+			#echo "$CONTAINER_IMAGE testing failed on command:"
+			#echo "$msg"
+			status="failure"
+			;;
+		"n" | "none")
+			status="pending";;
+		*)
+			msg ERROR "Unknown test status: $status"
+			return 1;;
+	esac 
+	local json="{\"description\": \"$msg\",\"state\": \"$status\",\"context\": \"biocontainers/status/check/$SOFTWARE\"}"
+	echo "Curl command:"
+	echo "curl -H '$hdr1' -H '$hdr2' -d '$json' $githuburl"
 }
 
 #############
@@ -186,8 +205,12 @@ if [ -f "$CMDS_FILE" ] ; then
 			args=$line
 		fi
 		#test_container "$entrypoint" "$args"
-		test_container "$entrypoint" "$args" || echo "Test FAILED"
+		if ! test_container "$entrypoint" "$args"; then
+			send_status $CONTAINER_IMAGE "failure" "Testing failed on command: $line"
+			exit 1
+		fi
 	done <"$CMDS_FILE"
+	send_status $CONTAINER_IMAGE "success" "All tests successful"
 else
 	echo "No $CMDS_FILE (test file) present, skipping tests"
 	send_comment "No $CMDS_FILE (test file) present, skipping tests"

--- a/test-built-container
+++ b/test-built-container
@@ -16,6 +16,7 @@ DEBUG=0
 CONTAINER_IMAGE=
 #CMDS_FILE=test_cmds.txt
 CMDS_FILE=
+TESTDATA_DIR=
 REPO="BioContainers/containers"
 GITHUB_STATUS_TOKEN=$GITHUB_AUTH_TOKEN
 COMMIT=$COMMIT_SHA1
@@ -32,7 +33,7 @@ HDR2="Authorization: token $GITHUB_STATUS_TOKEN"
 function print_help {
 	echo "Usage: $PROG_NAME [options] container_image"
 	echo
-	echo "   -t, --test-cmds            Path to test-cmds file."
+	echo "   -t, --test-cmds            Path to test-cmds.txt file (and its associated test files)."
 	echo "   -g, --debug                Debug mode."
 	echo "   -h, --help                 Print this help message."
 }
@@ -117,19 +118,16 @@ function test_container {
 
 	local entrypoint=$1
 	local args=$2
+	local mountpath=$3
 	local entrypoint_arg=
 
 	[ -z "$entrypoint" ] || entrypoint_arg="--entrypoint=$1"
 
 	echo "Running the following command:"
-	echo "docker run $entrypoint_arg $CONTAINER_IMAGE $args"
-	#docker run $entrypoint_arg $CONTAINER_IMAGE $args || exit 1
-	{
-		docker run $entrypoint_arg $CONTAINER_IMAGE $args &&
-		return 0
-	} || {
-		return 1
-	}
+	echo "docker run -v $mountpath:/biocontainers $entrypoint_arg $CONTAINER_IMAGE $args"
+	docker run -v $mountpath:/biocontainers $entrypoint_arg $CONTAINER_IMAGE $args
+	#echo "Command $?"
+	return $?
 }
 
 ################
@@ -145,11 +143,11 @@ function send_comment {
 		githuburl="https://api.github.com/repos/$REPO/issues/$PR_ID/comments"
 	fi
 	#echo "Cmd sent:"
-	#echo "curl -H '$header1' -H '$HDR2' -d '{\"body\": \"$comment\"}' $githuburl"
-        curl -H "$header1" \
-                -H "$HDR2" \
-		-d "{\"body\": \"$comment\"}" \
-		"$githuburl"
+	echo "curl -H '$header1' -H '$HDR2' -d '{\"body\": \"$comment\"}' $githuburl"
+        #curl -H "$header1" \
+                #-H "$HDR2" \
+		#-d "{\"body\": \"$comment\"}" \
+		#"$githuburl"
 }
 
 ###############
@@ -176,11 +174,11 @@ function send_status {
 			return 1;;
 	esac
 	#echo "Curl command:"
-	#echo "curl -H '$HDR1' -H '$HDR2' -d '$json' $githuburl"
-        curl -H "$HDR1" \
-                -H "$HDR2" \
-		-d "$json" \
-		"$githuburl"
+	echo "curl -H '$HDR1' -H '$HDR2' -d '$json' $githuburl"
+        #curl -H "$HDR1" \
+                #-H "$HDR2" \
+		#-d "$json" \
+		#"$githuburl"
 }
 
 #############
@@ -195,6 +193,8 @@ read_args "$@"
 
 # Test
 if [ -f "$CMDS_FILE" ] ; then
+	testdatapath=$(dirname $(realpath "$CMDS_FILE"))
+	#echo "Dir to mount: $testdatapath"
 	while read line ; do
 		has_entrypoint=$(echo $line | grep '^[^-]')
 		if [ -n "$has_entrypoint" ] ; then
@@ -204,8 +204,7 @@ if [ -f "$CMDS_FILE" ] ; then
 			entrypoint=
 			args=$line
 		fi
-		#test_container "$entrypoint" "$args"
-		if ! test_container "$entrypoint" "$args"; then
+		if ! test_container "$entrypoint" "$args" $testdatapath; then
 			send_status $CONTAINER_IMAGE "failure" "Testing failed on command: $line"
 			exit 1
 		fi


### PR DESCRIPTION
Gives the script the ability (using env vars) to post comment or status updates on github:

- A _comment_ is automatically posted if the optional **test-cmds.txt** file is not given as parameter/doesn't exist

- _Status_ is updated as **failure** if one of the tests (one per line) fails (returns !0)

- _Status_ is updated as **success** if all tests return with no error

The dir where **test-cmds.txt** is stored will also be mounted in the container's _/biocontainers_ dir to allow supplementary test data to be used in tests.