### PR TITLE
Accounting for ARG instructions in recipes

### DIFF
--- a/jenkins_container_version.py
+++ b/jenkins_container_version.py
@@ -19,8 +19,38 @@ dfp = DockerfileParser()
 dfp.content = content
 labels = dfp.labels
 
+###DockerfileParser doesn't know how to link ARG declarations to their subsequent use
+###Let's find a way around it
+
+def is_arg_used_here (arg_dict, recipe_line):
+	for crt_arg in arg_dict.keys():
+		if "$"+crt_arg in recipe_line:
+			print (recipe_line)
+
+##Parsing all ARGs
+recipe_args = dict()
+for crtInstr in dfp.structure:
+	if crtInstr['instruction']=="ARG":
+		#print ("Here's an ARG: "+crtInstr['value'])
+		parts = crtInstr['value'].split('=')
+		if len(parts) != 2:
+			print("An ARG instruction is wrongly formatted")
+			sys.exit(1)
+		recipe_args[parts[0]]=parts[1]
+		continue
+	##ARG instructions are at the start of the Dockerfile
+	##Within the same loop we can update the structure using what we've found
+	is_arg_used_here (recipe_args, crtInstr['value'])
+
+#print (dfp.envs)
+#print (dfp.labels)
+#print (recipe_args)
+#print (content)
+#print (dfp.structure)
+
 software_version = None
 if 'TOOL_VERSION' in os.environ:
+    print ("BLORG")
     labels['software.version'] = os.environ['TOOL_VERSION']
 if 'software.version' not in labels or not labels['software.version']:
     print("Failed to found software.version")

--- a/jenkins_container_version.py
+++ b/jenkins_container_version.py
@@ -1,4 +1,5 @@
 from dockerfile_parse import DockerfileParser
+from dockerfile_parse.util import WordSplitter
 import sys
 import os
 import logging
@@ -24,13 +25,13 @@ dfp.content = content
 recipe_args = dict()
 for crtInstr in dfp.structure:
 	if crtInstr['instruction']=="ARG":
-		#print ("Here's an ARG: "+crtInstr['value'])
 		parts = crtInstr['value'].split('=')
 		if len(parts) != 2:
 			print("An ARG instruction is wrongly formatted")
 			sys.exit(1)
 		#If an ARG can be parsed, it is added to a temp env dictionary
-		recipe_args[parts[0]]=parts[1]
+		crt_value = WordSplitter(parts[1]).dequote()
+		recipe_args[parts[0]]=crt_value
 
 if len(recipe_args.keys())>0:
 	#We must re-initialize the parser while including the ARG dictionary

--- a/jenkins_container_version.py
+++ b/jenkins_container_version.py
@@ -17,16 +17,8 @@ with open(docker_file, 'r') as content_file:
 
 dfp = DockerfileParser()
 dfp.content = content
-labels = dfp.labels
 
 ###DockerfileParser doesn't know how to link ARG declarations to their subsequent use
-###Let's find a way around it
-
-def is_arg_used_here (arg_dict, recipe_line):
-	for crt_arg in arg_dict.keys():
-		if "$"+crt_arg in recipe_line:
-			print (recipe_line)
-
 ##Parsing all ARGs
 recipe_args = dict()
 for crtInstr in dfp.structure:
@@ -36,17 +28,18 @@ for crtInstr in dfp.structure:
 		if len(parts) != 2:
 			print("An ARG instruction is wrongly formatted")
 			sys.exit(1)
+		#If an ARG can be parsed, it is added to a temp env dictionary
 		recipe_args[parts[0]]=parts[1]
-		continue
-	##ARG instructions are at the start of the Dockerfile
-	##Within the same loop we can update the structure using what we've found
-	is_arg_used_here (recipe_args, crtInstr['value'])
+
+if len(recipe_args.keys())>0:
+	#We must re-initialize the parser while including the ARG dictionary
+	print ("Updating parser with newly found ARG instructions")
+	dfp = DockerfileParser(parent_env = recipe_args)
+	dfp.content = content
 
 #print (dfp.envs)
 #print (dfp.labels)
-#print (recipe_args)
-#print (content)
-#print (dfp.structure)
+labels = dfp.labels
 
 software_version = None
 if 'TOOL_VERSION' in os.environ:

--- a/jenkins_container_version.py
+++ b/jenkins_container_version.py
@@ -15,6 +15,7 @@ if not docker_file or not os.path.exists(docker_file):
 with open(docker_file, 'r') as content_file:
         content = content_file.read()
 
+#First parsing so we can access the ARG instructions
 dfp = DockerfileParser()
 dfp.content = content
 
@@ -37,13 +38,11 @@ if len(recipe_args.keys())>0:
 	dfp = DockerfileParser(parent_env = recipe_args)
 	dfp.content = content
 
-#print (dfp.envs)
-#print (dfp.labels)
+#Moved here to avoid repeating this step
 labels = dfp.labels
 
 software_version = None
 if 'TOOL_VERSION' in os.environ:
-    print ("BLORG")
     labels['software.version'] = os.environ['TOOL_VERSION']
 if 'software.version' not in labels or not labels['software.version']:
     print("Failed to found software.version")


### PR DESCRIPTION
Since DockerfileParser doesn't include ARG declaration into its env, here is a workaround:     

- we run a first parsing as usual   
- creation of a dictionary with all ARG variables found     
- if there are any ARG found, we parse the document again using the dictionary as pre-existing env     
      
This worked successfully in correctly assigning an ARG variable to its later uses in a test Dockerfile.