### PR TITLE
Shared the fix between both script, added its import to both Dockerfiles

### DIFF
--- a/Dockerfile_jenkins_spec_check
+++ b/Dockerfile_jenkins_spec_check
@@ -3,5 +3,6 @@ RUN apt-get update
 RUN apt-get install -y python3-pip
 RUN pip3 install dockerfile_parse requests
 COPY jenkins_container_spec_check.py /root/
+COPY dockerparse_arg_fix.py /root/
 
 ENTRYPOINT ["/usr/bin/python3", "/root/jenkins_container_spec_check.py"]

--- a/Dockerfile_jenkins_version
+++ b/Dockerfile_jenkins_version
@@ -3,5 +3,6 @@ RUN apt-get update
 RUN apt-get install -y python3-pip
 RUN pip3 install dockerfile_parse requests
 COPY jenkins_container_version.py /root/
+COPY dockerparse_arg_fix.py /root/
 
 ENTRYPOINT ["/usr/bin/python3", "/root/jenkins_container_version.py"]

--- a/dockerparse_arg_fix.py
+++ b/dockerparse_arg_fix.py
@@ -1,0 +1,22 @@
+from dockerfile_parse import DockerfileParser
+from dockerfile_parse.util import WordSplitter
+
+def reload_arg_to_env (dfp, content):
+	recipe_args = dict()
+	for crtInstr in dfp.structure:
+		if crtInstr['instruction']=="ARG":
+			parts = crtInstr['value'].split('=')
+			if len(parts) != 2:
+				print("An ARG instruction is wrongly formatted")
+				sys.exit(1)
+			#If an ARG can be parsed, it is added to a temp env dictionary
+			crt_value = WordSplitter(parts[1]).dequote()
+			recipe_args[parts[0]]=crt_value
+
+	if len(recipe_args.keys())>0:
+		#We must re-initialize the parser while including the ARG dictionary
+		print ("Updating parser with newly found ARG instructions")
+		dfp = DockerfileParser(parent_env = recipe_args)
+		dfp.content = content
+
+	return dfp

--- a/jenkins_container_spec_check.py
+++ b/jenkins_container_spec_check.py
@@ -5,6 +5,8 @@ import os
 import logging
 import re
 
+import dockerparse_arg_fix
+
 def send_comment(comment):
     if 'GITHUB_STATUS_TOKEN' not in os.environ:
         logging.info(str({
@@ -93,6 +95,10 @@ with open(docker_file, 'r') as content_file:
 
 dfp = DockerfileParser()
 dfp.content = content
+
+#Need to double check on ARGs here
+dfp = dockerparse_arg_fix.reload_arg_to_env(dfp, content)
+
 labels = dfp.labels
 status = True
 msg = []


### PR DESCRIPTION
The fix is now available to both jenkins scripts (and their Docker images). 
    
A better way would be to add ARG handling to DockerfileParser. I'm looking into but hopefully this should do the trick in the meantime.